### PR TITLE
feat: add DBT license_inventory.

### DIFF
--- a/models/course_licensing/license_inventory.sql
+++ b/models/course_licensing/license_inventory.sql
@@ -1,0 +1,107 @@
+-- Step 1: Get the latest licenses for an institution
+WITH latest_licenses AS (
+    SELECT
+        id AS license_id,  -- License identifier
+        license_name,  -- Name of the license
+        MAX(time_last_dumped) AS latest_time_last_dumped  -- Most recent time for license data dump
+    FROM {{ source("event_sink", "course_licensing_license") }}
+    WHERE institution_id = '{{ var("institution_id", "79") }}'  -- Filter for a specific institution
+    GROUP BY id, license_name  -- Group by license id and name to get unique licenses
+),
+
+-- Step 2: Find the most recent record for each license
+latest_license_records AS (
+    SELECT
+        license_id,  -- License identifier
+        MAX(latest_time_last_dumped) AS latest_time_last_dumped  -- Latest dump time for each license
+    FROM latest_licenses
+    GROUP BY license_id  -- Group by license to get latest record for each
+),
+
+-- Step 3: Map licenses to CCX class IDs
+ccx_classes_by_license AS (
+    SELECT
+        license_id,  -- License identifier
+        ccx_id AS class_id  -- Corresponding CCX class ID
+    FROM {{ source("event_sink", "course_licensing_institution_ccx") }}
+),
+
+-- Step 4: Count active or expired enrollments per license
+enrollments_by_license AS (
+    SELECT
+        enrollment.license_id,  -- License identifier
+        COUNT(*) AS enrolled  -- Count of enrollments
+    FROM {{ source("event_sink", "course_licensing_licensed_enrollment") }} enrollment
+    JOIN (
+        SELECT id, MAX(time_last_dumped) AS latest_time_last_dumped  -- Latest enrollment records
+        FROM {{ source("event_sink", "course_licensing_licensed_enrollment") }}
+        GROUP BY id  -- Group by enrollment id to get the latest data
+    ) latest_enrollment_records
+    ON enrollment.id = latest_enrollment_records.id
+    AND enrollment.time_last_dumped = latest_enrollment_records.latest_time_last_dumped  -- Only select latest records
+    WHERE enrollment.is_active = 'True' OR enrollment.expired = 'True'  -- Include active or expired enrollments
+    GROUP BY enrollment.license_id  -- Group by license to count enrollments per license
+),
+
+-- Step 5: Calculate pending enrollments
+allowed_enrollments AS (
+    SELECT
+        allowed.course_id,  -- CCX course identifier
+        COUNT(DISTINCT allowed.email) AS pending  -- Count of unique pending enrollments
+    FROM {{ source("event_sink", "openedx_course_enrollment_allowed") }} allowed
+    WHERE allowed.course_id IN (  -- Only consider courses associated with the licenses
+        SELECT class_id FROM ccx_classes_by_license
+    )
+    AND lower(allowed.email) NOT IN (  -- Exclude students who are already enrolled
+        SELECT lower(student_email)
+        FROM {{ source("event_sink", "course_licensing_licensed_enrollment") }}
+    )
+    GROUP BY allowed.course_id  -- Group by course ID to count pending enrollments per course
+),
+
+-- Step 6: Summarize pending enrollments by license
+allowed_enrollments_by_license AS (
+    SELECT
+        ccx.license_id,             -- License identifier
+        SUM(allowed.pending) AS pending -- Total pending enrollments for this license
+    FROM ccx_classes_by_license ccx
+    LEFT JOIN allowed_enrollments allowed
+    ON ccx.class_id = allowed.course_id -- Join on course ID to match licenses with pending enrollments
+    GROUP BY ccx.license_id         -- Group by license to sum pending enrollments per license
+)
+
+-- Step 7: Final selection and calculation of key metrics
+SELECT
+    latest_licenses.license_id AS license_id,  -- License identifier
+    MAX(latest_licenses.license_name) AS license_name,  -- License name
+    SUM(toInt32(license_order.purchased_seats)) AS purchased_seats,  -- Total purchased seats
+    COALESCE(MAX(enrollments_by_license.enrolled), 0) AS enrolled,  -- Number of enrollments, or 0 if none
+    COALESCE(MAX(allowed_enrollments_by_license.pending), 0) AS pending,  -- Pending enrollments, or 0 if none
+    COALESCE(MAX(enrollments_by_license.enrolled), 0) 
+        + COALESCE(MAX(allowed_enrollments_by_license.pending), 0) AS enrollments_and_allowed,  -- Sum of enrolled and pending
+    SUM(toInt32(license_order.purchased_seats)) 
+        - COALESCE(MAX(enrollments_by_license.enrolled), 0)
+        - COALESCE(MAX(allowed_enrollments_by_license.pending), 0) AS remaining  -- Remaining seats after enrollments and pending
+FROM
+    latest_licenses
+JOIN
+    latest_license_records
+ON
+    latest_licenses.license_id = latest_license_records.license_id
+    AND latest_licenses.latest_time_last_dumped = latest_license_records.latest_time_last_dumped  -- Only use latest records
+JOIN
+    {{ source("event_sink", "course_licensing_license_order") }} license_order
+ON
+    latest_licenses.license_id = license_order.license_id  -- Join to get purchased seats for each license
+LEFT JOIN
+    enrollments_by_license
+ON
+    latest_licenses.license_id = enrollments_by_license.license_id  -- Left join to include enrollments data
+LEFT JOIN
+    allowed_enrollments_by_license
+ON
+    latest_licenses.license_id = allowed_enrollments_by_license.license_id  -- Left join to include pending enrollments data
+GROUP BY
+    latest_licenses.license_id  -- Group by license id for final result
+ORDER BY
+    latest_licenses.license_id;  -- Order results by license id

--- a/models/course_licensing/schema.yml
+++ b/models/course_licensing/schema.yml
@@ -1,0 +1,29 @@
+version: 2
+
+models:
+  - name: license_inventory
+    description: >
+      Aggregates key data for licenses, including purchased seats, licensed enrollments,
+      and allowed course enrollments per institution license.
+    columns:
+      - name: license_id
+        data_type: Int32
+        description: "Unique identifier for the license assigned to an institution."
+      - name: license_name
+        data_type: String
+        description: "Descriptive name of the license provided to an institution."
+      - name: purchased_seats
+        data_type: Int32
+        description: "Total number of seats purchased under this license."
+      - name: enrolled
+        data_type: Int32
+        description: "Count of active enrollments under the institution's license."
+      - name: pending
+        data_type: Int32
+        description: "Number of allowed enrollments for courses associated with the institution's license."
+      - name: enrollments_and_allowed
+        data_type: Int32
+        description: "Sum of enrolled and pending."
+      - name: remaining
+        data_type: Int32
+        description: "Purdchased seats minus enrollments_and_allowed which means the purchased seats allowed."

--- a/models/course_licensing/sources.yml
+++ b/models/course_licensing/sources.yml
@@ -1,0 +1,61 @@
+version: 2
+
+sources:
+  - name: event_sink
+    database: "{{ env_var('ASPECTS_EVENT_SINK_DATABASE', 'event_sink')}}"
+    tables:
+
+      - name: course_licensing_license
+        columns:
+          - name: dump_id
+          - name: time_last_dumped
+          - name: id
+          - name: created
+          - name: modified
+          - name: license_name
+          - name: institution_id
+          - name: institution_name
+          - name: master_courses
+          - name: course_access_duration
+          - name: status
+
+      - name: course_licensing_license_order
+        columns:
+          - name: dump_id
+          - name: time_last_dumped
+          - name: id
+          - name: created
+          - name: modified
+          - name: license_id
+          - name: license_name
+          - name: license_status
+          - name: order_reference
+          - name: purchased_seats
+          - name: active
+
+      - name: course_licensing_licensed_enrollment
+        columns:
+          - name: dump_id
+          - name: time_last_dumped
+          - name: id
+          - name: institution_id
+          - name: institution_name
+          - name: license_id
+          - name: license_name
+          - name: license_status
+          - name: student
+          - name: student_email
+          - name: class_name
+          - name: class_id
+          - name: is_active
+          - name: expired
+
+      - name: openedx_course_enrollment_allowed
+        columns:
+          - name: dump_id
+          - name: time_last_dumped
+          - name: id
+          - name: email
+          - name: course_id
+          - name: auto_enroll
+          - name: created


### PR DESCRIPTION
## Ticket

- https://agile-jira.pearson.com/browse/PADV-1649

## Description

This PR adds the license inventory DBT model, to show the licenses,  purchased seats, licensed enrollments,
and allowed course enrollments per institution license. This with the objective of implement a chart to show the following data:

![image](https://github.com/user-attachments/assets/fc7fea86-ca8e-49ba-a1e1-dbb5929bad62)

Where remaining enrollments means `remaining_enrollments = purchased_seats - licensed_enrollments - course_enrollment_allowed`.

## Changes made

- [x] Add license_inventory DBT model.
- [x] Add schema documentation
- [x] Add sources documentation

## How to test

- Set your tutor environment
- run `tutor dev do dbt -c "run" --only_changed False`
- Verify that the table was created correctly 

### Alternative way to test

Go to https://aspects.pearson.com/sqllab/

Put the following query which is for a particular institution in production environment:

```
WITH latest_licenses AS (
    SELECT 
        id AS license_id,
        license_name,
        MAX(time_last_dumped) AS latest_time_last_dumped
    FROM event_sink.course_licensing_license
    WHERE institution_id = '79'
    GROUP BY id, license_name
),
latest_license_records AS (
    SELECT 
        license_id,
        MAX(latest_time_last_dumped) AS latest_time_last_dumped
    FROM latest_licenses
    GROUP BY license_id
),
ccx_classes_by_license AS (
    SELECT 
        license_id,
        ccx_id AS class_id
    FROM event_sink.course_licensing_institution_ccx
),
enrollments_by_license AS (
    SELECT 
        enrollment.license_id,
        COUNT(*) AS enrollment_count
    FROM event_sink.course_licensing_licensed_enrollment enrollment
    JOIN (
        SELECT id, MAX(time_last_dumped) AS latest_time_last_dumped
        FROM event_sink.course_licensing_licensed_enrollment
        GROUP BY id
    ) latest_enrollment_records
    ON enrollment.id = latest_enrollment_records.id
    AND enrollment.time_last_dumped = latest_enrollment_records.latest_time_last_dumped
    WHERE enrollment.is_active = 'True'
    OR enrollment.expired = 'True'
    GROUP BY enrollment.license_id
),
allowed_enrollments AS (
    SELECT
        allowed.course_id,
        COUNT(DISTINCT allowed.email) AS allowed_enrollment_count
    FROM event_sink.openedx_course_enrollment_allowed allowed
    WHERE allowed.course_id IN (
        SELECT class_id
        FROM ccx_classes_by_license
    )
    AND lower(allowed.email) NOT IN (
        SELECT lower(student_email)
        FROM event_sink.course_licensing_licensed_enrollment
    )
    GROUP BY allowed.course_id
),
allowed_enrollments_by_license AS (
    SELECT
        ccx.license_id,
        SUM(allowed.allowed_enrollment_count) AS allowed_enrollment_count_by_license
    FROM ccx_classes_by_license ccx
    LEFT JOIN allowed_enrollments allowed
    ON ccx.class_id = allowed.course_id
    GROUP BY ccx.license_id
)

SELECT
    latest_licenses.license_id,
    MAX(latest_licenses.license_name) AS license_name,
    SUM(toInt32(license_order.purchased_seats)) AS total_purchased_seats,
    COALESCE(MAX(enrollments_by_license.enrollment_count), 0) AS enrollment_count,
    COALESCE(MAX(allowed_enrollments_by_license.allowed_enrollment_count_by_license), 0) AS allowed_enrollment_count_by_license,
    COALESCE(MAX(enrollments_by_license.enrollment_count), 0) 
        + COALESCE(MAX(allowed_enrollments_by_license.allowed_enrollment_count_by_license), 0) AS enrollments_and_allowed,
    SUM(toInt32(license_order.purchased_seats)) 
        - COALESCE(MAX(enrollments_by_license.enrollment_count), 0)
        - COALESCE(MAX(allowed_enrollments_by_license.allowed_enrollment_count_by_license), 0) AS Remaining
FROM
    latest_licenses
JOIN
    latest_license_records
ON
    latest_licenses.license_id = latest_license_records.license_id
    AND latest_licenses.latest_time_last_dumped = latest_license_records.latest_time_last_dumped
JOIN
    event_sink.course_licensing_license_order license_order
ON
    latest_licenses.license_id = license_order.license_id
LEFT JOIN
    enrollments_by_license
ON
    latest_licenses.license_id = enrollments_by_license.license_id
LEFT JOIN
    allowed_enrollments_by_license
ON
    latest_licenses.license_id = allowed_enrollments_by_license.license_id
GROUP BY
    latest_licenses.license_id
ORDER BY
    latest_licenses.license_id;
```

You should see the table:

![image](https://github.com/user-attachments/assets/37d38045-9469-4441-b8e6-fe689ba00b95)

Please verify the values and if you create the chart you should see:

![image](https://github.com/user-attachments/assets/b9000e38-449e-4516-af94-f5115f829b48)

## Reviewers

- [ ] @Squirrel18