### PR TITLE
chore: add course_licensing_institution_ccx in license inventory sources.

### DIFF
--- a/models/course_licensing/license_inventory.sql
+++ b/models/course_licensing/license_inventory.sql
@@ -1,3 +1,12 @@
+{{ 
+    config(
+        materialized="materialized_view",
+        engine=aspects.get_engine("ReplacingMergeTree()"),
+        primary_key="(license_id)",
+        order_by="(license_id)",
+    ) 
+}}
+
 -- Step 1: Get the latest licenses for an institution
 WITH latest_licenses AS (
     SELECT
@@ -5,7 +14,6 @@ WITH latest_licenses AS (
         license_name,  -- Name of the license
         MAX(time_last_dumped) AS latest_time_last_dumped  -- Most recent time for license data dump
     FROM {{ source("event_sink", "course_licensing_license") }}
-    WHERE institution_id = '{{ var("institution_id", "79") }}'  -- Filter for a specific institution
     GROUP BY id, license_name  -- Group by license id and name to get unique licenses
 ),
 
@@ -103,5 +111,3 @@ ON
     latest_licenses.license_id = allowed_enrollments_by_license.license_id  -- Left join to include pending enrollments data
 GROUP BY
     latest_licenses.license_id  -- Group by license id for final result
-ORDER BY
-    latest_licenses.license_id;  -- Order results by license id

--- a/models/course_licensing/sources.yml
+++ b/models/course_licensing/sources.yml
@@ -33,6 +33,23 @@ sources:
           - name: purchased_seats
           - name: active
 
+      - name: course_licensing_institution_ccx
+        columns:
+          - name: dump_id
+          - name: time_last_dumped
+          - name: id
+          - name: institution_id
+          - name: institution_name
+          - name: license_id
+          - name: license_name
+          - name: license_status
+          - name: ccx_id
+          - name: ccx_name
+          - name: master_course
+          - name: master_course_name
+          - name: min_students_allowed
+          - name: deleted
+
       - name: course_licensing_licensed_enrollment
         columns:
           - name: dump_id
@@ -48,6 +65,7 @@ sources:
           - name: class_name
           - name: class_id
           - name: is_active
+          - name: end_date
           - name: expired
 
       - name: openedx_course_enrollment_allowed


### PR DESCRIPTION
## Description

This PR adds the event_sink.course_licensing_intitution_ccx table into the sources file to maintain up to date the information of the tables used for license_inventory query. Also the config init in license inventory is added.

## Changes made

- [x] Add course_licensing_institution_ccx in license inventory chart
- [x] Add config in licence inventory

## How to test

- Start your tutor environment with course licensing feature
- Run `tutor dev/local do init-clickhouse to create the respective tables`
- Run `tutor dev/local do dbt -c "run" --only_changed False`
- Verify that the table was created in `tutor dev/local exec clickhouse clickhouse-client`
- Run into the clickhouse container `SELECT * FROM reporting_event_sink.license_inventory;`

## Reviewers

- [x] @MAAngamarca 