### PR TITLE
chore: add institution_id column in license inventory table.

### DIFF
--- a/models/course_licensing/license_inventory.sql
+++ b/models/course_licensing/license_inventory.sql
@@ -12,9 +12,10 @@ WITH latest_licenses AS (
     SELECT
         id AS license_id,  -- License identifier
         license_name,  -- Name of the license
+        institution_id,  -- Institution identifier
         MAX(time_last_dumped) AS latest_time_last_dumped  -- Most recent time for license data dump
     FROM {{ source("event_sink", "course_licensing_license") }}
-    GROUP BY id, license_name  -- Group by license id and name to get unique licenses
+    GROUP BY id, license_name, institution_id  -- Group by license id, name and institution_id to get unique licenses
 ),
 
 -- Step 2: Find the most recent record for each license
@@ -81,6 +82,7 @@ allowed_enrollments_by_license AS (
 -- Step 7: Final selection and calculation of key metrics
 SELECT
     latest_licenses.license_id AS license_id,  -- License identifier
+    MAX(latest_licenses.institution_id) AS institution_id,  -- Institution identifier
     MAX(latest_licenses.license_name) AS license_name,  -- License name
     SUM(toInt32(license_order.purchased_seats)) AS purchased_seats,  -- Total purchased seats
     COALESCE(MAX(enrollments_by_license.enrolled), 0) AS enrolled,  -- Number of enrollments, or 0 if none

--- a/models/course_licensing/schema.yml
+++ b/models/course_licensing/schema.yml
@@ -9,6 +9,9 @@ models:
       - name: license_id
         data_type: Int32
         description: "Unique identifier for the license assigned to an institution."
+      - name: institution_id
+        data_type: Int32
+        description: "Unique identifier for the institution."
       - name: license_name
         data_type: String
         description: "Descriptive name of the license provided to an institution."


### PR DESCRIPTION
## Ticket

- https://agile-jira.pearson.com/browse/PADV-1783

## Description

This PR adds institution_id into the license inventory table to filter it when it's required.

## Changes Made

- [x] Add institution_id in license_inventory.sql
- [x] Add the description in the schema

## How to test

- Start your tutor environment with course licensing feature
- Run `tutor dev/local do init-clickhouse to create the respective tables`
- Run `tutor dev/local do dbt -c "run" --only_changed False`
- Verify that the table was created in `tutor dev/local exec clickhouse clickhouse-client`
- Run into the clickhouse container `SELECT * FROM reporting_event_sink.license_inventory;` 

## Reviewers

- [ ] @MAAngamarca 